### PR TITLE
exchange idr0054 link

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -82,7 +82,7 @@ sites:
   - name: IDR (well 828419)
     url: https://idr.openmicroscopy.org/webclient/?show=well-828419
   - name: idr0054 sample image
-    url: https://idr.openmicroscopy.org/webgateway/render_image/5025551/
+    url: https://idr.openmicroscopy.org/webgateway/render_image/5025551/0/0/?c=1|0:150$FF0000&m=c
   - name: IDR (mineotaur)
     url: https://idr.openmicroscopy.org/mineotaur/
   - name: IDR (well 592371)


### PR DESCRIPTION
The upptime was not getting a correct response to its check for link in idr0054 study on the newly-migrated IDR.
This PR updates the link.

See https://github.com/IDR/upptime/issues/9584


cc @will-moore @dominikl 